### PR TITLE
SLING-9839 execute Sonar with Java11

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,42 @@
 
  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-Sling Jenkins jobs creation
----------------------------
+# Sling Jenkins Shared Library
 
-The scripts found in this folder are used to create the Jenkins jobs
-listed at https://builds.apache.org/view/S-Z/view/Sling/
 
 The master branch of this module is pulled directly from the Jenkins
-builds, no deployment step is required to activate changes.
+builds and used as [Jenkins Shared Library](https://www.jenkins.io/doc/book/pipeline/shared-libraries/) with name `sling`, no deployment step is required to activate changes as the `master` branch is loaded implicitly.
 
-See https://cwiki.apache.org/confluence/display/SLING/Sling+Jenkins+Setup
+See <https://cwiki.apache.org/confluence/display/SLING/Sling+Jenkins+Setup>
 for more info.
+
+## Test Changes
+
+As changes to master are active immediately on all jobs, it is recommended to test any changes in the Jenkins Shared Library by pushing them to a dedicated branch (in this example named `mybranch`) and then reference that branch from within a branch of any other project, by using a `Jenkinsfile` explicitly via `@Library` as follows
+
+```
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@Library('sling@mybranch') _
+slingOsgiBundleBuild()
+
+```
+
+When the branch job related to the modified `Jenkinsfile` is built, it will use the library from `mybranch` instead of `master`. Other jobs are not affected.

--- a/vars/slingOsgiBundleBuild.groovy
+++ b/vars/slingOsgiBundleBuild.groovy
@@ -50,8 +50,9 @@ def call(Map params = [:]) {
                         }
                         // Alls params are set, let's execute using #withCrendentials to hide and mask Robert's token
                         withCredentials([string(credentialsId: 'sonarcloud-token-rombert', variable: 'SONAR_TOKEN')]) {
+                            // always build with Java 11 (that is the minimum version supported: https://sonarcloud.io/documentation/appendices/end-of-support/)
                             withMaven(maven: globalConfig.mvnVersion, 
-                                jdk: jenkinsJdkLabel(jobConfig.jdks[0], globalConfig),
+                                jdk: jenkinsJdkLabel(11, globalConfig),
                                 publisherStrategy: 'EXPLICIT') {
                                     try {
                                          sh  "mvn -U clean verify sonar:sonar ${sonarcloudParams} -Pci"


### PR DESCRIPTION
This change will execute Sonar always with Java11. For modules not yet buildable with Java11 it will mark the job as unstable (example in https://ci-builds.apache.org/blue/organizations/jenkins/Sling%2Fmodules%2Fsling-org-apache-sling-jcr-webconsole/detail/feature%2FSLING-9839-sonar-with-java11/3/pipeline/33.)