### PR TITLE
SLING-11673 - Jenkins sanity check stage executed even when no parallel builds are triggered

### DIFF
--- a/vars/slingOsgiBundleBuild.groovy
+++ b/vars/slingOsgiBundleBuild.groovy
@@ -97,7 +97,8 @@ def call(Map params = [:]) {
             }
 
             // do a quick sanity check first without tests if multiple parallel builds are required
-            if ( stepsMap.size() > 1 ) {
+            // the stepsMap has at least one entry due to the failFast entry
+            if ( stepsMap.size() > 2 ) {
                 node(globalConfig.mainNodeLabel) {
                     stage("Sanity Check") {
                         checkout scm


### PR DESCRIPTION
Correct the stepsMap size check